### PR TITLE
Make a stack observable

### DIFF
--- a/lib/src/utils/undo-manager.spec.ts
+++ b/lib/src/utils/undo-manager.spec.ts
@@ -194,6 +194,39 @@ describe('UndoManager', () => {
     });
   });
 
+  describe('.stack$', () => {
+    it('fires (only) when the stack (or current state index) changes', () => {
+      let callCount = 0;
+      let lastValue = [] as State[];
+      undoManager.stack$.subscribe((stack) => {
+        ++callCount;
+        lastValue = stack;
+      })
+      expect(callCount).toBe(1);
+      expect(lastValue.map((state) => { return state.counter })).toEqual([0]);
+
+      store('counter').set(1);
+      expect(callCount).toBe(2);
+      expect(lastValue.map((state) => { return state.counter })).toEqual([0, 1]);
+
+      undoManager.undo();
+      expect(callCount).toBe(3);
+      expect(lastValue.map((state) => { return state.counter })).toEqual([0, 1]);
+
+      undoManager.redo();
+      expect(callCount).toBe(4);
+      expect(lastValue.map((state) => { return state.counter })).toEqual([0, 1]);
+
+      store('counter').set(10);
+      expect(callCount).toBe(5);
+      expect(lastValue.map((state) => { return state.counter })).toEqual([0, 1, 10]);
+
+      undoManager.reset();
+      expect(callCount).toBe(6);
+      expect(lastValue.map((state) => { return state.counter })).toEqual([10]);
+    })
+  })
+
   describe('.reset()', () => {
     it('does not affect the store', () => {
       undoManager.reset();

--- a/lib/src/utils/undo-manager.ts
+++ b/lib/src/utils/undo-manager.ts
@@ -9,6 +9,7 @@ export abstract class UndoManager<StateType, UndoStateType> {
 
   private canUndoSubject = new BehaviorSubject(false);
   private canRedoSubject = new BehaviorSubject(false);
+  private stackSubject = new BehaviorSubject([] as UndoStateType[]);
 
   /**
    * An observable that emits the result of `canUndo()` every time that value changes.
@@ -21,6 +22,11 @@ export abstract class UndoManager<StateType, UndoStateType> {
    */
   canRedo$: Observable<boolean> =
     this.canRedoSubject.pipe(distinctUntilChanged());
+
+  /**
+   * An observable that emits the current stack whenever the stack or `currentStateIndex` changes
+   */
+  stack$: Observable<UndoStateType[]> = this.stackSubject.asObservable();
 
   /**
    * @param maxDepth The maximum size of the history before discarding the oldest state. `0` means no limit.
@@ -125,5 +131,6 @@ export abstract class UndoManager<StateType, UndoStateType> {
   private fireUndoChanges() {
     this.canUndoSubject.next(this.canUndo());
     this.canRedoSubject.next(this.canRedo());
+    this.stackSubject.next(this.stack);
   }
 }


### PR DESCRIPTION
This makes a `stack$` observable to which things using an undo manager can subscribe to know when a new state was either pushed onto the stack or applied from the stack.