### PR TITLE
Changed batching behavior

### DIFF
--- a/projects/ng-app-state/src/lib/actions/batch-action.ts
+++ b/projects/ng-app-state/src/lib/actions/batch-action.ts
@@ -1,21 +1,24 @@
+import { get } from "micro-dash";
 import { AppStateAction } from "./app-state-action";
 
 /** @private */
 export class BatchAction extends AppStateAction {
   private children: AppStateAction[] = [];
 
-  constructor() {
+  constructor(private rootSnapshot: any) {
     super("batch", []);
   }
 
   public dispatch(action: AppStateAction) {
     this.children.push(action);
+    this.rootSnapshot = action.execute(this.rootSnapshot);
   }
 
   public execute<T extends object>(rootState: T) {
-    return this.children.reduce(
-      (curState, child) => child.execute(curState),
-      rootState,
-    );
+    return this.rootSnapshot;
+  }
+
+  public getState(path: string[]) {
+    return path.length ? get(this.rootSnapshot, path) : this.rootSnapshot;
   }
 }

--- a/projects/ng-app-state/src/lib/app-store.ts
+++ b/projects/ng-app-state/src/lib/app-store.ts
@@ -4,15 +4,22 @@ import { TreeBasedObservableFactory } from "./tree-based-observable/tree-based-o
 import { StoreObject } from "./store-object";
 
 export class AppStore<T extends object> extends StoreObject<T> {
-  private actionSubject = new Subject<Action>();
-
   /**
    * Emits the actions dispatched through this object.
    */
-  public action$: Observable<Action> = this.actionSubject.asObservable();
+  public action$: Observable<Action>;
 
-  constructor(private store: Store<any>, key: string, initialState: T) {
-    super(new TreeBasedObservableFactory(store), [key], store);
+  private store: Store<any>;
+  private actionSubject: Subject<Action>;
+
+  constructor(store: Store<any>, key: string, initialState: T) {
+    const observableFactory = new TreeBasedObservableFactory(store);
+    super(observableFactory, [key], store, observableFactory);
+
+    this.store = store;
+    this.actionSubject = new Subject<Action>();
+    this.action$ = this.actionSubject.asObservable();
+
     this.set(initialState);
   }
 

--- a/projects/ng-app-state/src/lib/store-object.spec.ts
+++ b/projects/ng-app-state/src/lib/store-object.spec.ts
@@ -187,6 +187,19 @@ describe("StoreObject", () => {
       expect(fires).toBe(2);
       expect(store.state()).toEqual({ counter: 3, nested: { state: 6 } });
     });
+
+    it("works when nested", () => {
+      store.batch((batch1) => {
+        batch1("counter").set(1);
+        batch1.batch((batch2) => {
+          expect(batch2.state().counter).toBe(1);
+          batch2("counter").set(2);
+          expect(batch2.state().counter).toBe(2);
+        });
+        expect(batch1.state().counter).toBe(2);
+      });
+      expect(store.state().counter).toBe(2);
+    });
   });
 
   describe(".inBatch()", () => {
@@ -479,6 +492,16 @@ describe("StoreObject", () => {
       expect(store.state().nested.state).toBe(1);
       expect(store("nested").state().state).toBe(1);
       expect(store("nested")("state").state()).toBe(1);
+    });
+
+    it("gets the in-progress value of a batch", () => {
+      store.batch((batch) => {
+        store("counter").set(1);
+        expect(store.state().counter).toBe(1);
+
+        store("counter").set(2);
+        expect(store.state().counter).toBe(2);
+      });
     });
 
     it("gets the new subvalue even it has a later subscriber (production bug)", () => {

--- a/projects/ng-app-state/src/lib/tree-based-observable/tree-based-observable-factory.ts
+++ b/projects/ng-app-state/src/lib/tree-based-observable/tree-based-observable-factory.ts
@@ -23,7 +23,8 @@ export class TreeBasedObservableFactory {
   }
 
   public getState(path: string[]) {
-    return get(this.getRootState(), path);
+    const rootState = this.getRootState();
+    return path.length ? get(rootState, path) : rootState;
   }
 
   private ensureNodeAt(path: string[]) {

--- a/projects/ng-app-state/src/lib/utils/push-to-store-array.spec.ts
+++ b/projects/ng-app-state/src/lib/utils/push-to-store-array.spec.ts
@@ -40,9 +40,18 @@ describe("pushToStoreArray", () => {
 
   it("works within a batch (production bug)", () => {
     store.set([]);
+    let so1: StoreObject<number>;
+    let so2: StoreObject<number>;
+
     store.batch((batch) => {
-      pushToStoreArray(batch, 1);
+      so1 = pushToStoreArray(batch, 1);
+      so2 = pushToStoreArray(batch, 2);
+
+      expect(so1.state()).toEqual(1);
+      expect(so2.state()).toEqual(2);
     });
-    expect(store.state()).toEqual([1]);
+    expect(store.state()).toEqual([1, 2]);
+    expect(so1!.state()).toEqual(1);
+    expect(so2!.state()).toEqual(2);
   });
 });


### PR DESCRIPTION
Batches will maintain their own fork of the full global state, then commit it to the store when the batch completes. Calls to `state()` on the batch will now reflect changes made during the batch so far.